### PR TITLE
Allowing for multiple SSL certs to be added from a directory

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -147,9 +147,9 @@ void Config::from_cli(int argc, char** argv) {
       CHECK_ARG("--use-stdout");
       use_stdout = atoi(argv[i + 1]) != 0;
       i++;
-    } else if (strcmp(arg, "--trust-cert-file") == 0) {
-      CHECK_ARG("--trust-cert-file");
-      trusted_cert_file = argv[i + 1] != 0;
+    } else if (strcmp(arg, "--trust-cert") == 0) {
+      CHECK_ARG("--trust-cert");
+      trusted_cert = argv[i + 1];
       i++;
     }
     else {
@@ -166,11 +166,11 @@ void Config::dump(FILE* file) {
                 "--hosts \"%s\" --type %s --label \"%s\" --protocol-version %d "
                 "--num-threads %d --num-io-threads %d --num-core-connections %d --num-requests %d --num-concurrent-requests %d "
                 "--num-partition-keys %d --data-size %d --batch-size %d --log-level %d --sampling-rate %d "
-                "--use-token-aware %d --use-prepared %d --use-ssl %d --use-stdout %d\n",
+                "--use-token-aware %d --use-prepared %d --use-ssl %d --trust-cert %s --use-stdout %d\n",
           hosts.c_str(), type.c_str(), label.c_str(), protocol_version,
           num_threads, num_io_threads, num_core_connections, num_requests, num_concurrent_requests,
           num_partition_keys, data_size, batch_size, static_cast<int>(log_level), sampling_rate,
-          use_token_aware, use_prepared, use_ssl, use_stdout);
+          use_token_aware, use_prepared, use_ssl, trusted_cert.c_str(), use_stdout);
 }
 
 std::string Config::filename() {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -10,7 +10,7 @@ struct Config {
   Config()
     : hosts("127.0.0.1")
     , type("select")
-    , trusted_cert_file("trusted_cert.pem")
+    , trusted_cert("trusted_cert.pem")
     , num_threads(1)
     , num_io_threads(1)
     , num_core_connections(1)
@@ -33,7 +33,7 @@ struct Config {
 
   std::string hosts;
   std::string type;
-  std::string trusted_cert_file;
+  std::string trusted_cert;
   std::string label;
   int num_threads;
   int num_io_threads;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,9 +39,9 @@ CassCluster* create_cluster(const Config& config) {
   if (config.use_ssl) {
     CassSsl* ssl = cass_ssl_new();
     cass_ssl_set_verify_flags(ssl, CASS_SSL_VERIFY_PEER_CERT);
-    if (!load_trusted_cert_file(config.trusted_cert_file.c_str(), ssl)) {
+    if (!load_trusted_cert(config.trusted_cert.c_str(), ssl)) {
       fprintf(stderr, "Failed to load certificate '%s' disabling peer verification\n",
-              config.trusted_cert_file.c_str());
+              config.trusted_cert.c_str());
       cass_ssl_set_verify_flags(ssl, CASS_SSL_VERIFY_NONE);
     }
     cass_cluster_set_ssl(cluster, ssl);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -56,7 +56,8 @@ void print_error(CassFuture* future);
 
 CassError prepare_query(CassSession* session, const char* query, const CassPrepared** prepared);
 
-int load_trusted_cert_file(const char* file, CassSsl* ssl);
+int load_trusted_cert(const char* file_or_directory, CassSsl* ssl);
+int load_trusted_cert_directory(const char* directory, CassSsl* ssl);
 
 CassError connect_session(CassSession* session, const CassCluster* cluster);
 


### PR DESCRIPTION
* Fixed a bug with --trust-cert-file
* Renamed `--trust-cert-file` => `--trust-cert`